### PR TITLE
[enh] Dump helper in template

### DIFF
--- a/includes/services/TemplateEngine.php
+++ b/includes/services/TemplateEngine.php
@@ -101,6 +101,12 @@ class TemplateEngine
         $this->twig->addGlobal('isInIframe', testUrlInIframe());
 
         // Adds Helpers
+        $this->addTwigHelper('dump', function ($var) {
+            if (isset($this->wiki->config['debug_template']) && $this->wiki->config['debug_template'] == 'yes') {
+                return dump($var);
+            }
+            return '';
+        });
         $this->addTwigHelper('_t', function ($key, $params = []) {
             return html_entity_decode(_t($key, $params));
         });


### PR DESCRIPTION
In order to ease the template creation, this helper allows to dump a var (for example _context var) and knows which data are available and how.

Usage in a twig template: {{ dump(_context) }}

You need to define `"debug_template" => "yes"` in the wakka_config.